### PR TITLE
Add notice about broken Lab 4 video link and clarify playback error (…

### DIFF
--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -382,7 +382,9 @@ In this exercise, we will begin the provisioning process for a Teams Phone. We w
 ### Task 1 - Perform remote provisioning of Teams Phones
 
 > [!NOTE]
-> The instructions provided here are for reference only and will not complete successfully.  To view the demonstration of these steps, visit [https://www.microsoft.com/videoplayer/embed/RWN0wC](https://www.microsoft.com/videoplayer/embed/RWN0wC).
+> The instructions provided here are for reference only and will not complete successfully.  The demonstration video referenced in this step [https://www.microsoft.com/videoplayer/embed/RWN0wC](https://www.microsoft.com/videoplayer/embed/RWN0wC) is currently not accessible and may display a *Playback Error*.
+> The correct video link will be provided as soon as it is available.
+
 
 In this task, you will provision a Teams Phone device in the Teams administration center.
 


### PR DESCRIPTION
Fixes #82 

## Summary

This pull request addresses **Issue #82**, where the demonstration video link used in **Lab 4 – Manage your Teams Phone environment** is no longer accessible and returns a *Playback Error*.  

To help learners avoid confusion and unnecessary troubleshooting, the NOTE block in the lab has been updated to clearly state that the video link is currently unavailable.

## What was changed

- Updated the existing `[!NOTE]` section beneath Task 1.
- Added a clear message explaining that the referenced video is not accessible.
- Removed dependency on the assumption that the link works.

## Updated NOTE text

> [!NOTE]  
> The instructions provided here are for reference only and will not complete successfully.  
> The demonstration video referenced in this step (https://www.microsoft.com/videoplayer/embed/RWN0wC) is currently not accessible and may display a *Playback Error*.  
> The correct video link will be provided as soon as it is available.

## Why this change is important

Learners may interpret the playback error as a problem with:
- Their browser  
- The Skillable VM  
- Microsoft Teams configuration  
- Network or tenant restrictions  

This update prevents confusion and improves the learning experience by providing clarity directly in the lab instructions.
