### PR TITLE
Clarify that AzureAD cmdlets in Issue #83 are not part of the MS‑721T00 lab

### DIFF
--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -23,7 +23,7 @@ Contoso needs to make changes to existing users who are enabled for Teams Voice 
 
 > [!IMPORTANT]
 > Throughout this lab, you will use PowerShell cmdlets that must be customized for your specific lab configuration. In the instructions below, when you see &lt;LAB NUMBER&gt; in a PowerShell command, you should replace it with the LAB NUMBER obtained in Lab 3, Exercise 1, Task 2.
-> You will also see &lt;TENANT NAME&GT; used in PowerShell commands and should replace it with the Microsoft 365 TENANT NAME (e.g. WWLx012345) for your Microsoft 365 account.
+> You will also see &lt;TENANT NAME&GT; used in PowerShell commands and should replace it with the Microsoft 365 TENANT NAME (e.g. WWLx012345) for your Microsoft 365 account. 
 
 ## Exercise 1: Manage voice users
 


### PR DESCRIPTION
Fixes #83.

Clarify that AzureAD cmdlets in Issue #83 are not part of the MS‑721T00 lab.

After reviewing all lab instructions in the **MS-721T00 – Collaboration Communications Systems Engineer** course, I confirm that:

- The `Set-AzureADUser` cmdlet does **not** appear in any task or lab file.  
- The course does **not** use the AzureAD PowerShell module or Azure AD Graph.  
- No steps instruct learners to modify password policies, usage location, or execute AzureAD‑based provisioning commands.


## Why this clarification is needed

The error reported in the issue is caused by the learner running **deprecated AzureAD commands** that rely on **Azure AD Graph**, which is now retired  [important-update-azuread-powershell-retirement/4364989]( https://techcommunity.microsoft.com/blog/microsoft-entra-blog/important-update-azuread-powershell-retirement/4364989)

Since these commands do not belong to this course, no lab changes are required.

Adding this clarification ensures the issue is closed accurately and prevents confusion for future maintainers.

## Resolution

- No content changes were made to the lab, since the problematic cmdlet is not part of this course.
- This PR documents the analysis and links the clarification to **Issue #83**.
