### PR TITLE
Clarify that deprecated AzureAD cmdlets in Issue #84 are not part of …

### DIFF
--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -23,7 +23,7 @@ Contoso needs to make changes to existing users who are enabled for Teams Voice 
 
 > [!IMPORTANT]
 > Throughout this lab, you will use PowerShell cmdlets that must be customized for your specific lab configuration. In the instructions below, when you see &lt;LAB NUMBER&gt; in a PowerShell command, you should replace it with the LAB NUMBER obtained in Lab 3, Exercise 1, Task 2.
-> You will also see &lt;TENANT NAME&GT; used in PowerShell commands and should replace it with the Microsoft 365 TENANT NAME (e.g. WWLx012345) for your Microsoft 365 account.
+> You will also see &lt;TENANT NAME&GT; used in PowerShell commands and should replace it with the Microsoft 365 TENANT NAME (e.g. WWLx012345) for your Microsoft 365 account. 
 
 ## Exercise 1: Manage voice users
 


### PR DESCRIPTION
Fixes #84 

This PR clarifies that the **AzureAD cmdlets shown in Issue #84 are not part of the MS‑721T00 lab**, including Lab 04: *Manage your Teams Voice Environment*.

After reviewing the full lab content, no instructions ask learners to use the AzureAD module or any Azure AD Graph–based PowerShell commands. The lab uses only supported modules:

- MicrosoftTeams PowerShell  
- Exchange Online PowerShell  
- Microsoft Graph PowerShell


The following deprecated AzureAD commands were executed by the learner:

```powershell
$MTRLicense = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicense
$MTRLicense.SkuId = "4cde982a-ede4-4409-9ae6-b003453c8ea6"

$Licenses = New-Object -TypeName Microsoft.Open.AzureAD.Model.AssignedLicenses
$Licenses.AddLicenses = $MTRLicense

Set-AzureADUserLicense -ObjectId mtr01@WWLx844748.onmicrosoft.com -AssignedLicenses $Licenses
```

## 🔍 Why this clarification is needed

Issue #84 reflects the learner executing deprecated AzureAD commands that do not appear in the lab instructions.
