### PR TITLE
Lab 02:Clarify Step 5 to instruct learners to add each subnet separately

### DIFF
--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -493,7 +493,7 @@ Perform the following steps.
 
 1. Leave IPv4 Selected for **IP Version**.
 
-1. Enter the Bellevue Subnet network ID, since our Bellevue Office subnet is 10.10.10.0/24, the network ID is **10.10.10.0**. Additionally also add **192.168.0.0** for a later task.
+1. Enter the Bellevue Subnet network ID, since our Bellevue Office subnet is 10.10.10.0/24, Enter the network ID **10.10.10.0** in the **Subnet** field. After completing steps 3–8, repeat them again to add the second subnet **192.168.0.0** , which will be used in a later task.
 
 1. Enter **Bellevue Subnet** as the **Description**.
 


### PR DESCRIPTION
Fixes #86 

This pull request updates **Lab 02 – Exercise 3**, Step 5, to clarify how learners should enter subnet IDs in the Microsoft Teams Admin Center.

The previous wording suggested that two subnet IDs should be entered at the same time, which caused confusion because only **one subnet can be added per action**.  
The revised instructions now clearly explain that:

- The first subnet **10.10.10.0** must be added by completing steps **3–8**.  
- Learners must then **repeat steps 3–8** to add the second subnet **192.168.0.0**, which is required in a later task.

## Updated -Exercise 3-Step 5

Enter the **Bellevue Subnet network ID**, since our Bellevue Office subnet is 10.10.10.0/24, Enter the network ID **10.10.10.0** in the **Subnet** field. After completing steps 3–8, repeat them again to add the second subnet **192.168.0.0** , which will be used in a later task.


This update resolves **Issue #86** by eliminating ambiguity and ensuring that learners correctly add both subnets one at a time, matching the expected configuration shown in the issue screenshot.