### PR TITLE
Update Task 3 introduction to reflect correct call‑delegation permiss…

### DIFF
--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -98,7 +98,7 @@ Nestor is now configured to use Direct Routing.
 
 ### Task 3 - Configure call delegation
 
-In this task, you will configure Nestor Wilke so that Allan Deyoung is a delegate of Nestor Wilke and is allowed to make calls on their behalf, but not receive calls.
+In this task, you will configure Nestor Wilke so that Allan Deyoung is a delegate of Nestor Wilke and is allowed to make and receive calls on their behalf.
 
 1. You are still signed in to MS721-CLIENT01 as “Admin” and signed into the **Microsoft Teams admin center** as **Allan Deyoung**.
 


### PR DESCRIPTION
Fixes #87 

This pull request updates the introduction text for **Lab 04 – Exercise 1, Task 3** to correctly reflect the permissions that learners configure during the call‑delegation steps.

Previously, the task introduction stated that Allan Deyoung would be configured as a delegate of Nestor Wilke and *allowed to make calls on their behalf, but not receive them*.  
However, the actual configuration steps instruct learners to leave the **Permission** value set to **Make and receive calls**, which means Allan is allowed to both make **and** receive calls on Nestor’s behalf.

This inconsistency caused confusion and was highlighted in Issue #87 (and previously in Issue #64).

## Updated Task Introduction

The task introduction now correctly states:

> *In this task, you will configure Nestor Wilke so that Allan Deyoung is a delegate of Nestor Wilke and is allowed to make and receive calls on their behalf.*

This updated text now aligns with:

- The actual configuration learners perform in Step 8  
- The expected behavior shown in the Teams Admin Center  
- The fix previously made for Issue #64  

By correcting the introductory text, learners receive a consistent and accurate explanation of the call‑delegation behavior they will configure.