### PR TITLE
lab05-ex3-task1-Add note for resolving Install‑Module ExchangeOnlineM…

### DIFF
--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -302,6 +302,7 @@ In this task, you will sign into Microsoft Exchange PowerShell and configure the
     Install-Module ExchangeOnlineManagement
 
     ```
+    > NOTE: If the Install-Module ExchangeOnlineManagement command fails, an older version of the module may already be installed. Close PowerShell, open a new Administrator‑elevated window, and run the command: Uninstall-Module -Name ExchangeOnlineManagement -AllVersions -Force . Then run the installation command again.
 
 1. In Windows PowerShell, enter the following cmdlet to connect to Exchange Online Management:
 


### PR DESCRIPTION
Fixes #90 

# Summary

This pull request addresses an issue in **Exercise 3, Task 1**, where learners may encounter an error during the installation of the **Exchange Online Management module** on **MS721‑CLIENT01**.

Because the virtual machine may already contain an older version of the module, the command  
`Install-Module ExchangeOnlineManagement` can fail. This leads learners to believe there is a permissions or configuration issue, even though the root cause is a conflicting pre‑installed module.

To improve clarity and prevent unnecessary troubleshooting, a short troubleshooting **NOTE** has been added below Step 3.

# What was changed

- Added a concise troubleshooting note below Step 3 in Exercise 3, Task 1.  
- Clarified that the installation error occurs due to an older module version already installed on the VM.  
- Provided the correct command to remove conflicting versions of the module.  

# Updated NOTE text

> **Note:**  
> If the `Install-Module ExchangeOnlineManagement` command fails, an older version of the module may already be installed. Close PowerShell, open a new **Administrator‑elevated** window, and run:  
> ```powershell
> Uninstall-Module -Name ExchangeOnlineManagement -AllVersions -Force
> ```  
> Then run the installation command again.


# Suggestions

- Remove the existing PowerShell module on the virtual machine
- Install the latest module

# Why this change is important

Learners may misinterpret the installation failure as an issue with:

- PowerShell permissions  
- The VM  
- Their Microsoft 365 tenant  
- Network or connectivity restrictions  

