### PR TITLE
Lab06 update instructions ex1 and ex2

### DIFF
--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -141,7 +141,7 @@ In this task, you will create a voice application policy which will give users r
   
     - **Agent Monitor Mode:** Takeover
     
-    - **Agent Monitoring:** Agent
+    - **Agent Monitor Notification Mode:** Agent
   
   - **Call Queue Reporting** Toggle All Settings to **Only Authorized Queues**
 

--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -83,7 +83,7 @@ You have successfully created a Teams Phone Resource Account for a Call Queue an
 
 ### Task 3 - Creating a Call Queue
 
-In this task, you will sign into the Microsoft Teams admin center and create a Auto Attendant.
+In this task, you will sign into the Microsoft Teams admin center and create a Call Queue.
 
 1. You are still signed in to MS721-CLIENT01 as “Admin” and signed into the **Microsoft Teams admin center** as **MOD Administrator**.
 
@@ -95,9 +95,13 @@ In this task, you will sign into the Microsoft Teams admin center and create a A
 
 	  - **Add a name for your call queue:** CQ_MainLine
 
+      - **Language:** English (United States)
+
+      - **Select** Classic setup
+
 	  - **Resource Accounts:** CQ_MainLine@&lt;Lab Domain&gt;.onmicrosoft.com
 
-	  - **Language:** English (United States)
+	  
 
   - **Call Answering Tab**
 

--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -177,7 +177,7 @@ In this exercise, you will test the Queues app.
 
 In this task, you will sign into the Microsoft Teams client and access the Queues App.
 
-1. You are still signed in to MS721-CLIENT02 as “Admin” and signed into Microsoft Teams as **Megan Bowen**
+1. You are still signed in to MS721-CLIENT02 as “Admin” and signed into Microsoft Teams as **Isaiah Langer**
 
 1. In the Teams client, click the three dots **...** on the left side app bar and then search & select the app called **Queues.**
 


### PR DESCRIPTION
 Fixes #91 
 
This pull request addresses the issues reported in **Exercise 1, Task 3**, **Exercise 1, Task 4**, and **Exercise 2, Task 1**, where several instructions in the lab were outdated or incorrect.

- The introductory text in Exercise 1, Task 3 incorrectly stated that the learner is creating an Auto Attendant instead of a Call Queue.
- The Call Queue creation wizard in the Teams Admin Center has changed and required updated steps.
- Exercise 1, Task 4 referenced an incorrect configuration label.
- Exercise 2, Task 1 assumed the learner was signed in as Megan, but the VM is signed in as Isaiah.

These corrections ensure the instructions accurately reflect the current Teams Admin Center experience and reduce confusion for learners.


## What was changed

### Exercise 1, Task 3
- Updated the introductory text to correctly indicate that the task creates a **Call Queue**, not an Auto Attendant.
- Updated the wizard steps to match the current Teams Admin Center UI.
- Added missing configuration details:
  - Select: Classic setup

### Exercise 1, Task 4
- Corrected the label from:
  - "Agent Monitoring: Agent"
- To the correct value:
  - "Agent monitor notification mode: Agent"

### Exercise 2, Task 1
- Updated the instructions to reflect that the Teams client on CLIENT02 is still signed in as **Isaiah**, not Megan.

---

## Why this change is important

These updates correct misleading or outdated instructions that could cause learners to:

- Follow incorrect UI paths in the Teams Admin Center
- Use outdated or incorrect configuration values
- Become confused when the user signed into the VM does not match the instructions

