### PR TITLE
Lab05-ex2-task2-Update Surface Hub 3 Troubleshooting Note

### DIFF
--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -328,7 +328,7 @@ In this task, you will sign into the a virtual Surface Hub 3 running Teams Rooms
 
     ![A screenshot showing the Teams Rooms welcome screen.](Linked_Image_Files/M05_L05_E03_T02_01.png)
 
-    > NOTE: If you see an error stating that there is not an active internet connection, reset the virtual machine to restart the application. It likely booted before the RRAS box had fully started.
+    > NOTE: If you see an error stating that there is not an active internet connection, reset the virtual machine to restart the application. It likely booted before the RRAS box had fully started. If the Surface Hub 3 still cannot sign in using the `CONF_Room1` resource account, complete an initial sign‑in with this account on **MS721‑CLIENT01** using the Teams desktop app or https://teams.microsoft.com. This first sign‑in finalizes any password updates and completes Teams provisioning for the account.When updating the password, use the **MOD Administrator password**. After signing in successfully on CLIENT01, return to **MS721‑SH3** and sign in on the Surface Hub again.
 
 1. On the next page click **Accept** to the **End User Agreement** and then click **Manual Setup**. Enter the following credentials:
 


### PR DESCRIPTION
 Fixes #89 
 
# Pull Request – Update Surface Hub 3 Troubleshooting Note

## Summary
This update enhances the troubleshooting guidance for Surface Hub 3 sign‑in issues using MS721-SH3 by adding the required first‑time Teams activation step for the `CONF_Room1` resource account.

## Changes Included
- Expanded the existing NOTE block  
- Added first‑time sign‑in activation step on MS721‑CLIENT01  
- Added clarification about using the MOD Administrator password  

## Updated NOTE

> **NOTE:** If you see an error stating that there is not an active internet connection, reset the virtual machine to restart the application. It likely booted before the RRAS VM had fully started.  
>  
> If the Surface Hub 3 still cannot sign in using the `CONF_Room1` resource account, complete an initial sign‑in with this account on **MS721‑CLIENT01** using the Teams desktop app or https://teams.microsoft.com.  
>  
> When updating the password, use the **MOD Administrator password** if prompted instead of the generic User password.  
>  
> This initial sign‑in finalizes password updates and completes Teams provisioning for the account. After successfully signing in on CLIENT01, return to **MS721‑SH3** and sign in on the Surface Hub again.

These updates ensure that learners can successfully authenticate the Surface Hub 3 using the resource account and proceed with the lab workflow without being blocked by provisioning or password‑re