### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
+++ b/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
@@ -1,8 +1,19 @@
 ---
 lab:
-    title: 'Lab 01: Configure the lab environment'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab 01: Configure the lab environment'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: In the labs for this course, you are taking on the role of Allan Deyoung,
+    Contoso Ltd.’s Collaboration Communications Systems Engineer. You have deployed
+    Microsoft 365 in a lab environment, and you have been tasked with completing a
+    pilot project that tests the Voice and Phone device management features in Microsoft
+    Teams as they relate to Contoso's business requirements.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Microsoft 365
+  - Microsoft Teams
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -1,8 +1,12 @@
 ---
 lab:
-    title: 'Lab 02: Configure your environment for Teams Voice Usage'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab 02: Configure your environment for Teams Voice Usage'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: Contoso wants to set up Teams Phone for their users.
+  duration: 155 minutes
+  level: 300
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
+++ b/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Lab: Expand your Teams Voice Environment to use Direct Routing'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab: Expand your Teams Voice Environment to use Direct Routing'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: As part of the expanding business, the organization has an existing
+    SIP trunk in its primary data center. The contractual obligations mean that it’s
+    more cost-effective to utilize the SIP trunk and move to Microsoft Calling Plans
+    later. As part of the move, Megan will be moved from the old telephone system
+    to the new Microsoft Phone solution.
+  duration: 200 minutes
+  level: 400
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Lab 04: Manage your Teams Voice Environment'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 04: Manage your Teams Voice Environment'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: Contoso needs to make changes to existing users who are enabled for
+    Teams Voice and add Teams Devices. Whilst making changes, support tickets have
+    been raised due to problems users have reported with connectivity and troubleshooting
+    must be performed.
+  duration: 180 minutes
+  level: 400
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Lab 05: Manage Microsoft Teams Devices'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 05: Manage Microsoft Teams Devices'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: As part of the expanding business, the organization has began deploying
+    various types of Microsoft Teams devices in their organization. You need to manage
+    the deployment of these devices.
+  duration: 120 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Microsoft Teams
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Lab 06: Manage Microsoft Teams Premium'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 06: Manage Microsoft Teams Premium'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: As part of the expanding business, the organization has began needing
+    access to more specialized areas of Microsoft Teams for different departments.
+  duration: 120 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Microsoft Teams
 ---
 
 > **Abstract:**  


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/LAB_AK_01_prepare_lab_environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_05_manage_teams_devices.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_06_manage_teams_premium.md` (description,duration,level,islab,primarytopics)
