### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
+++ b/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
@@ -1,8 +1,14 @@
 ---
 lab:
-    title: 'Lab 01: Configure the lab environment'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab 01: Configure the lab environment'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: You have just started the pilot project. In this first lab you will set up a personalized Microsoft 365 user account for Allan that will be used throughout all the labs in this course. This first exercise also requires that you perform several setup tasks that will initialize your trial tenant for the remaining labs in this course. You must configure your trial tenant, create a personalized Teams Service user account in Microsoft 365 for Kate, configure several test users and groups that will be used throughout the remaining labs, and request a certificate signed by a public certificate authority.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft 365
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
+++ b/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 01: Configure the lab environment'
   type: Answer Key
   module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
-  description: You have just started the pilot project. In this first lab you will set up a personalized Microsoft 365 user account for Allan that will be used throughout all the labs in this course. This first exercise also requires that you perform several setup tasks that will initialize your trial tenant for the remaining labs in this course. You must configure your trial tenant, create a personalized Teams Service user account in Microsoft 365 for Kate, configure several test users and groups that will be used throughout the remaining labs, and request a certificate signed by a public certificate authority.
+  description: In this lab, you will configure the foundational Microsoft 365 environment for Contoso Ltd., including user accounts, permissions, and licenses, to support Teams collaboration and voice features. The scenario guides you through preparing the environment for subsequent labs by setting up users, groups, and initial Teams administration tools.
   duration: 30 minutes
   level: 200
   islab: true

--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -1,8 +1,12 @@
 ---
 lab:
-    title: 'Lab 02: Configure your environment for Teams Voice Usage'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab 02: Configure your environment for Teams Voice Usage'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: In this exercise, you will configure some key voice settings and policies required for the Contoso users to utilize voice services in context with the company policies.
+  duration: 155 minutes
+  level: 300
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 02: Configure your environment for Teams Voice Usage'
   type: Answer Key
   module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
-  description: In this exercise, you will configure some key voice settings and policies required for the Contoso users to utilize voice services in context with the company policies.
+  description: This lab focuses on preparing the Contoso environment for Microsoft Teams Phone by evaluating network readiness, configuring network topology, emergency calling, voice policies, and assigning phone numbers. The scenario covers end-to-end setup for Teams Voice, including call queues, auto attendants, and audio conferencing.
   duration: 155 minutes
   level: 300
   islab: true

--- a/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
+++ b/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab: Expand your Teams Voice Environment to use Direct Routing'
   type: Answer Key
   module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
-  description: In the following task, you will assign the voice routing policy you created in an earlier task to your users.
+  description: In this lab, you will expand the Teams Phone environment by configuring Direct Routing with a Session Border Controller (SBC), integrating on-premises telephony, and assigning voice routing policies. The scenario walks through deploying, configuring, and validating Direct Routing for hybrid voice connectivity.
   duration: 200 minutes
   level: 400
   islab: true

--- a/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
+++ b/Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md
@@ -1,8 +1,12 @@
 ---
 lab:
-    title: 'Lab: Expand your Teams Voice Environment to use Direct Routing'
-    type: 'Answer Key'
-    module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  title: 'Lab: Expand your Teams Voice Environment to use Direct Routing'
+  type: Answer Key
+  module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
+  description: In the following task, you will assign the voice routing policy you created in an earlier task to your users.
+  duration: 200 minutes
+  level: 400
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 04: Manage your Teams Voice Environment'
   type: Answer Key
   module: 'Learning Path 02: Manage Teams collaboration communications systems'
-  description: Next, you will use Graph PowerShell to assign the Teams Rooms Pro trial license you acquired in a previous lab and configure the resource account password policy.
+  description: This lab guides you through managing and troubleshooting Teams Phone users, configuring call queues and auto attendants, provisioning Teams devices, and monitoring call quality. The scenario addresses real-world support and operational tasks in a Teams Phone deployment.
   duration: 180 minutes
   level: 400
   islab: true

--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -1,8 +1,12 @@
 ---
 lab:
-    title: 'Lab 04: Manage your Teams Voice Environment'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 04: Manage your Teams Voice Environment'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: Next, you will use Graph PowerShell to assign the Teams Rooms Pro trial license you acquired in a previous lab and configure the resource account password policy.
+  duration: 180 minutes
+  level: 400
+  islab: true
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -1,8 +1,14 @@
 ---
 lab:
-    title: 'Lab 05: Manage Microsoft Teams Devices'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 05: Manage Microsoft Teams Devices'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: In this task, you will connect to Microsoft Teams PowerShell and assign the previously created policy to a user. This policy can only be assigned, managed, and created in PowerShell.
+  duration: 120 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Microsoft Teams
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -3,7 +3,7 @@ lab:
   title: 'Lab 05: Manage Microsoft Teams Devices'
   type: Answer Key
   module: 'Learning Path 02: Manage Teams collaboration communications systems'
-  description: In this task, you will connect to Microsoft Teams PowerShell and assign the previously created policy to a user. This policy can only be assigned, managed, and created in PowerShell.
+  description: In this lab, you will configure, deploy, and manage Microsoft Teams devices, including shared devices, Teams Rooms, and Surface Hub. The scenario covers account setup, licensing, device policies, and remote management for Teams-enabled hardware.
   duration: 120 minutes
   level: 400
   islab: true

--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -1,8 +1,14 @@
 ---
 lab:
-    title: 'Lab 06: Manage Microsoft Teams Premium'
-    type: 'Answer Key'
-    module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  title: 'Lab 06: Manage Microsoft Teams Premium'
+  type: Answer Key
+  module: 'Learning Path 02: Manage Teams collaboration communications systems'
+  description: In this exercise, you will create custom meeting templates for users that have Microsoft Teams Premium licensing. This will customize the meeting join experience for members of the meeting.
+  duration: 120 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft Teams
 ---
 
 > **Abstract:**  

--- a/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
+++ b/Instructions/Labs/LAB_AK_06_manage_teams_premium.md
@@ -3,9 +3,9 @@ lab:
   title: 'Lab 06: Manage Microsoft Teams Premium'
   type: Answer Key
   module: 'Learning Path 02: Manage Teams collaboration communications systems'
-  description: In this exercise, you will create custom meeting templates for users that have Microsoft Teams Premium licensing. This will customize the meeting join experience for members of the meeting.
+  description: This lab explores advanced Teams Premium features, including configuring the Queues app, voice application policies, and meeting customization. The scenario demonstrates how to enable, assign, and validate premium capabilities for specialized Teams experiences.
   duration: 120 minutes
-  level: 200
+  level: 300
   islab: true
   primarytopics:
     - Microsoft Teams


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/LAB_AK_01_prepare_lab_environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_03_expand_environment_direct_routing.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_AK_05_manage_teams_devices.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_AK_06_manage_teams_premium.md` (description,duration,level,islab,primarytopics)
