### PR TITLE
Update lab instructions for Teams Phone and Direct Routing setup

### DIFF
--- a/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
+++ b/Instructions/Labs/LAB_AK_01_prepare_lab_environment.md
@@ -105,6 +105,9 @@ You have successfully signed into your test clients and reviewed the overall num
 
 As an admin, you can assign the Teams Domestic Calling Plan license that gives users the right to be assigned a phone number and make and receive PSTN calls. In this task, you will activate the **Teams Domestic Calling Plan license** for five users. All users already have an E5 license, so all they need is a calling plan license.
 
+> [!NOTE]
+> Direct number ordering through the Teams admin center is currently unavailable in this trial tenant due to a compliance verification requirement. The Calling Plan license is still assigned here so the license inventory is staged correctly, but later labs (Lab 3 onward) assign phone numbers to users and resource accounts via **Direct Routing** through the lab's Session Border Controller (SBC) instead of through a Microsoft Calling Plan.
+
 1. You are still signed in to MS721-CLIENT01 as **Admin** and in the **Microsoft 365 admin center** as **MOD Administrator**.
 
 1. On the Microsoft 365 admin center page, in the left navigation, select **Users**, then **Active users**.
@@ -130,7 +133,7 @@ As an admin, you can assign the Teams Domestic Calling Plan license that gives u
 
 1. Close the browser window at the end of the task.
 
-You have successfully assigned the licenses to five users and activated Teams Premium features for these accounts. You will continue with additional tasks for assigning phone numbers in a later exercise. 
+You have successfully assigned the licenses to five users and activated Teams Premium features for these accounts. Because direct number ordering isn't available in this trial tenant, phone numbers are assigned through Direct Routing PowerShell in later labs rather than through the Teams admin center.
 
 ## Exercise 2: Setup PowerShell for Microsoft Teams administration
 

--- a/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
+++ b/Instructions/Labs/LAB_AK_02_configure_environment_teams_voice.md
@@ -3,14 +3,14 @@ lab:
   title: 'Lab 02: Configure your environment for Teams Voice Usage'
   type: Answer Key
   module: 'Learning Path 01: Plan and design Teams collaboration communications systems'
-  description: This lab focuses on preparing the Contoso environment for Microsoft Teams Phone by evaluating network readiness, configuring network topology, emergency calling, voice policies, and assigning phone numbers. The scenario covers end-to-end setup for Teams Voice, including call queues, auto attendants, and audio conferencing.
-  duration: 155 minutes
+  description: This lab focuses on preparing the Contoso environment for Microsoft Teams Phone by evaluating network readiness, configuring network topology, emergency calling, and voice policies. The scenario covers the foundation for Teams Voice that subsequent labs build on through Direct Routing.
+  duration: 115 minutes
   level: 300
   islab: true
 ---
 
 > **Abstract:**  
-> This lab focuses on preparing the Contoso environment for Microsoft Teams Phone by evaluating network readiness, configuring network topology, emergency calling, voice policies, and assigning phone numbers. The scenario covers end-to-end setup for Teams Voice, including call queues, auto attendants, and audio conferencing.
+> This lab focuses on preparing the Contoso environment for Microsoft Teams Phone by evaluating network readiness, configuring network topology, emergency calling, and voice policies. The scenario covers the foundation for Teams Voice that subsequent labs build on through Direct Routing.
 
 # Lab 02: Configure your environment for Teams Phone
 # Student lab answer key
@@ -25,7 +25,7 @@ Firstly, our administrator wants to ensure the network is capable of running Mic
 
 - Test our network performance with the Teams Network Assessment
 
-Next, we need to configure our tenant ready for acquiring phone numbers and assigning them to users, before we can acquire and assign phone numbers we need to configure our network topology and emergency calling addresses
+Next, we need to configure our tenant for Teams Phone usage. Before phone numbers can be assigned to users, we need to configure our network topology and emergency calling addresses.
 
 - Configure a basic network topology and emergency calling addresses
 
@@ -33,19 +33,16 @@ Voice Policies allow us to configure specific parts of Teams Phone. We require e
 
 - Configure Voice policies to meet Contoso requirements
 
-Now we will acquire and assign phone numbers to a user and perform a test call and configure audio conferencing for our users
+Finally, we will review our default audio conferencing settings.
 
-- Assign licenses and phone numbers to a user for calling
+- Review audio conferencing settings
 
-- Configure audio conferencing
-
-Finally, we will configure Call Queues and Auto Attendants for inbound calls to Contoso
-
-- Configure Call Queues and Auto Attendants 
+> [!NOTE]
+> Direct number ordering through the Teams admin center is currently unavailable in this trial tenant due to a compliance verification requirement. Phone numbers for users and resource accounts are assigned through **Direct Routing** PowerShell in Lab 4 and Lab 5 after the Session Border Controller (SBC) is deployed in Lab 3. The Auto Attendant and Call Queue scenarios used elsewhere in the course are configured in Lab 4 once Direct Routing is in place.
 
 ## Lab Setup
 
-  - **Estimated Time to complete**: 155 minutes
+  - **Estimated Time to complete**: 115 minutes
 
 ## Instructions
 
@@ -414,7 +411,7 @@ You have successfully added the public IP that clients will appear from for the 
 
 ### Task 3 - Add an emergency address
 
-In this task, you will create an emergency location. This is needed before you can order calling plan numbers.
+In this task, you will create an emergency location. This is needed before you can assign phone numbers to users for Teams Phone and is also required for dynamic emergency calling configuration in later labs.
 
 1. From the last task, you are still signed in to MS721-CLIENT01 as “Admin” and have the **Microsoft Teams Admin Center** open as **Allan Deyoung**.
 
@@ -703,159 +700,17 @@ There is a persistent nuisance caller calling users in the Bellevue office and w
 
 You have successfully blocked all inbound calls from 1 (412) 555-1111 via PowerShell to end the unwanted calls from that number. 
 
-## Exercise 5 (See NOTE): Prepare for calling
-
-> [!NOTE]
-> This exercise is unable to be completed at this time. Due to a new verification requirement to meet compliance standards, ordering service and subscriber numbers for Microsoft Teams Phone is not possible in our tenant environment.  We hope to mitigate this issue in the future, but in the meantime, use the steps below as a general reference.  There is also a simulated demo experience here: [Microsoft Teams Phone - IT Pro](https://regale.cloud/Microsoft/viewer/2716/teams-phone-it-pro-guided-simulation-dec-2023-update/index.html#/0/0)
+## Exercise 5: Review audio conferencing settings
 
 ### Exercise Duration
 
-  - **Estimated Time to complete**: 20 minutes
+  - **Estimated Time to complete**: 5 minutes
 
-In this exercise, you will set up a user for Teams Phone with a Microsoft Calling plan. 
+In this exercise, you will review the default Microsoft PSTN audio conferencing settings for the tenant.
 
-### Task 1 - Order a service number
+### Task 1 - Review the default Audio Conferencing Bridge
 
-In this task, you will order a phone number in the Teams Admin Center to assign to an auto attendant in a future lab.
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and in the **Microsoft Teams admin center** as **Allan Deyoung**
-
-1. In the **Microsoft Teams admin center**, select **Voice** on the left menu, then select **Phone numbers**.
-
-1. Under **Numbers**, select **Add**.
-
-1. At the top of the page, enter a name for your order **New service number for Sales Group**.
-
-1. For **description** enter **New service number for Shared Calling users in the Sales Group**.
-
-1. Select **United States** as **Country or region**.
-
-1. For Number Type, select **Auto Attendant (Toll)**.
-
-1. For Operator, select **Microsoft**.
-
-1. The Quantity field will now appear, enter **1**.
-
-1. For **Search for new numbers** select **Search by area code** and enter **206**.
-
-> [!NOTE]
-> The phone numbers that are available in different regions will vary and **206** numbers may not be available. Try other area codes in the US and Canada, such as **308** in Nebraska.  The area code of the phone number does not need to match the emergency address location.
-
-1. When all fields are complete, select **Next**. Microsoft will now reserve phone numbers in the chosen area code. If there are no numbers available for your selected State/City combination, select another State/City and try again.
-
-1. Verify the area code and phone number, then select **Place Order**.
-
-1. You will see “Thank you, your order has been placed!”, select **Finish**.
-
-1. In the voice, under **phone numbers**, you should see your number. Note in some cases this may take 5-10 minutes to appear.
-
-1. Leave the browser window open at the end of the task.
-
-You have successfully ordered an auto attendant service number through the Teams admin center.
-
-### Task 2 - Order a user (subscriber) number
-
-In this task, you will order a phone number in the Teams Admin Center to assign to Isaiah Langer.
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and in the **Microsoft Teams admin center** as **Allan Deyoung**
-
-1. In the **Microsoft Teams admin center**, select **Voice** on the left menu, then select **Phone numbers**.
-
-1. Under **Numbers**, select **Add**.
-
-1. At the top of the page, enter a name for your order **New user (subscriber) number for Isaiah Langer**.
-
-1. For **description** enter **New user (subscriber) number for Isaiah Langer**.
-
-1. Select **United States** as **Country or region**.
-
-1. For Number Type, select **User (subscriber)**.
-
-1. For Operator, select **Microsoft**.
-
-1. The Quantity field will now appear, enter **1**.
-
-1. For **Search for new numbers** select **Search by area code** and enter **206**.
-
-> [!NOTE]
-> The phone numbers that are available in different regions will vary and **206** numbers may not be available. Try other area codes in the US and Canada, such as **308** in Nebraska.  The area code of the phone number does not need to match the emergency address location.
-
-1. When all fields are complete, select **Next**. Microsoft will now reserve phone numbers in the chosen area code. If there are no numbers available for your selected State/City combination, select another State/City and try again.
-
-1. Verify the area code and phone number, then select **Place Order**.
-
-1. You will see “Thank you, your order has been placed!”, select **Finish**.
-
-1. In the voice, under **phone numbers**, you should see your number. Note in some cases this may take 5-10 minutes to appear.
-
-1. Leave the browser window open at the end of the task.
-
-You have successfully ordered a User (subscriber) phone number through the Teams admin center.
-
-### Task 3 - Assign a phone number to Isaiah Langer
-
-Before a user can make calls, they need a phone number. In this task, you will assign the phone number you ordered earlier to Isaiah Langer.
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and have the **Microsoft Teams admin center** open as **Allan Deyoung**.
-
-1. Select **Voice** and the **Phone numbers** tab.
-
-1. Select the new user phone number we ordered in Task 2 for Isaiah Langer.
-
-1. Select **Edit** from the top table menu.
-
-1. Enter **Isaiah Langer** in the **Assigned To** field, then select **Assign**.
-
-1. Under **Emergency location**, select **Search by city**, and then enter **Bellevue** and select the address you verified earlier.
-
-1. Select **Apply** and close any additional windows.
-
-1. The phone number is now assigned to Isaiah.
-
-You have successfully assigned a phone number to Isaiah Langer.
-
-### Task 4 - Test phone calls
-
-Now Isaiah has a calling plan and phone number and we will perform a test call to validate the functionality of the configuration.
-
-1. Switch to **MS721-CLIENT02** and sign in as **Admin** with the credentials provided to you.
-
-1. Open the Edge browser and navigate to [https://teams.microsoft.com](https://teams.microsoft.com/). Sign in with the credentials of Isaiah.
-
-1. Log in as Isaiah Langer (*IsaiahL@<TenantName>.onmicrosoft.com*) using the password you assigned in the previous lab. When a **Save password** dialog is displayed, select **Never**.
-
-1. When a **Stay signed in?** dialog is displayed, select **Yes**.
-
-1. Close any popup or welcome messages until you are at the Teams main screen..
-
-1. Select the **Calls** button on the left rail.
-
-1. Dial **+18776967786** and press call.
-
-1. If your lab machine prompted, you to use your microphone select **Allow**.
-
-1. If you are prompted by Windows Defender Firewall for Microsoft Teams select **Allow Access**
-
-1. Note the call connects.
-
-1. Press the red hang-up button to disconnect the call.
-
-Now we confirmed that Isaiah can make a PSTN call in Teams.
-
-## Exercise 6 (See NOTE): Configure audio conferencing settings
-
-> [!NOTE]
-> This exercise is unable to be completed at this time. Due to a new verification requirement to meet compliance standards, ordering service and subscriber numbers for Microsoft Teams Phone is not possible in our tenant environment.  We hope to mitigate this issue in the future, but in the meantime, use the steps below as a general reference.  There is also a simulated demo experience here: [Microsoft Teams Phone - IT Pro](https://regale.cloud/Microsoft/viewer/2716/teams-phone-it-pro-guided-simulation-dec-2023-update/index.html#/0/0)
-
-### Exercise Duration
-
-  - **Estimated Time to complete**: 10 minutes
-
-In this exercise, you will configure Microsoft PSTN audio conferencing to meet the organization's requirements.
-
-### Task 1 - Set a default Audio Conferencing Bridge
-
-The default phone number of your conference bridge defines the caller ID that will be used when an outbound call is placed by a participant or the organizer from within a meeting. E.g., they are dialing out to either connect themselves via PSTN or to “dial in” another participant on PSTN.
+The default phone number of your conference bridge defines the caller ID that will be used when an outbound call is placed by a participant or the organizer from within a meeting. For example, when they're dialing out to either connect themselves via PSTN or to "dial in" another participant on PSTN.
 
 Contoso does a lot of work with companies in New York and would prefer a New York number as their default audio conference bridge.
 
@@ -871,61 +726,10 @@ Contoso does a lot of work with companies in New York and would prefer a New Yor
 
 1. Leave the browser window open at the end of the task.
 
-You have successfully set a New York City, United States number as the default audio conference number.
+You have successfully reviewed the audio conference bridge numbers available to the tenant.
 
-### Task 2 – Order a new Conference Bridge Number
-
-Contoso would like to have a conference number for their customers to dial specifically in the United States 920 area code. In this task, we will order that number and add it to our tenant.
-
-In this task, you will order a new Dedicated conference bridge toll number. This will be a dedicated number for people to dial into Contoso conferences.
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and have the **Microsoft Teams admin center** open as **Allan Deyoung**.
-
-1. Navigate and select **Voice** on the left menu, then select **Phone numbers**.
-
-1. Under **Phone numbers**, select the **Add**.
-
-1. At the top of the page, enter a name for your order **Dedicated conference number**.
-
-1. For **description** enter **Dedicated conference number**.
-
-1. Select United States as **Country or region**.
-
-1. For **Number Type**, select **Dedicated conference bridge (Toll)**.
-
-1. Select **Microsoft** in the Operator field, the Quantity field will now appear, enter **1**.
-
-1. For **Search for new numbers** select **search by area code** and enter **920**.
-
-1. When all fields are complete, select **Next**, Microsoft will now reserve and present some numbers for you. If you see “We can't find any phone numbers for the area code you entered.” Try another US area code for this exercise. If you really did want a specific city, you would contact the PSTN service desk to find out if/when there is availability.
-
-1. You should see 1 reserved number, select **Place Order**.
-
-1. You will see “Thank you, your order has been placed!”, select **Finish**.
-
-1. In the voice, under **Phone numbers**, you should see your number. Note in some cases this may take 5-10 minutes to appear.
-
-1. Leave the browser window open at the end of the task.
-
-You have successfully ordered a new dedicated conference toll phone number through the Teams admin center.
-
-### Task 3 - Configure a New Conference Bridge Number
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and have the **Microsoft Teams admin center** open as **Allan Deyoung**.
-
-1. In the left navigation menu select **Meetings** and **Conference bridges**. 
-
-1. Select **Add** and select **Toll number**. 
-
-1. Select the new conference number you acquired in task 2 from the drop-down list of Toll numbers.
-
-1. Select **Apply**.
-
-1. You will be back at the list of conference bridge numbers, sort the list by **Type** to confirm you have a new Dedicated conference bridge. It may take a few minutes for the bridge to appear. You can refresh the page by moving to a different page in the Teams Admin Center and then returning to the **Conference bridges** page.
-
-1. Leave the browser window open at the end of the task.
-
-You have successfully set up a new dedicated conference bridge number.
+> [!NOTE]
+> In a production environment, you can also acquire dedicated conference bridge numbers in specific area codes through the Teams admin center. Because direct number ordering is unavailable in this trial tenant, that step is omitted from the lab. For production guidance, see [Phone numbers for Audio Conferencing in Microsoft Teams](https://learn.microsoft.com/microsoftteams/phone-numbers-for-audio-conferencing-in-teams).
 
 ## Next Steps
 

--- a/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
+++ b/Instructions/Labs/LAB_AK_04_manage_teams_voice_environment.md
@@ -96,9 +96,16 @@ In this task, an existing user who isn’t enabled for voice services must be en
     Set-CsPhoneNumberAssignment -Identity NestorW@lab<LAB NUMBER>.o365ready.com -PhoneNumber "+14255551122" -PhoneNumberType DirectRouting
     ```
 
+1. Now grant the same voice routing policy to **Isaiah Langer** and assign Isaiah a Direct Routing phone number. (In a production environment without the current tenant restrictions, you would order Isaiah a Calling Plan number through the Teams admin center. Because that's unavailable in this lab tenant, you'll use Direct Routing through the SBC deployed in Lab 3 instead.)
+
+    ```powershell
+    Grant-CsOnlineVoiceRoutingPolicy -Identity IsaiahL@lab<LAB NUMBER>.o365ready.com -PolicyName "NA-National"
+    Set-CsPhoneNumberAssignment -Identity IsaiahL@lab<LAB NUMBER>.o365ready.com -PhoneNumber "+14255551133" -PhoneNumberType DirectRouting
+    ```
+
 1. Close the PowerShell Window at the end of the task.
 
-Nestor is now configured to use Direct Routing.
+Nestor and Isaiah are now configured to use Direct Routing.
 
 ### Task 3 - Configure call delegation
 
@@ -152,7 +159,7 @@ In this task, you validate audio conferencing is enabled for Isaiah Langer and c
 
 1. Check if **Audio Conferencing** is switched to **On**.
 
-1. Select the **Toll number** dropdown and change it to **+1 689 206 9333 Orlando, United States**. (**Note**: That particular number might not be available.  Choose another number as appropriate.)
+1. Select the **Toll number** dropdown and change it to **+1 689 206 9333 Orlando, United States**. If that particular number isn't available, choose any other available toll number from the dropdown.
 
 1. Select **Apply**.
 
@@ -522,16 +529,13 @@ As devices are provisioned or joined, they will be displayed in the **Devices** 
 
 After applying a tag to devices, you can then use the **Search** box in the device list to choose **Select what you want to search by**, and then choose **Tags**. Enter the tag you’ve assigned to devices, and these devices will be displayed in the search results.
 
-## Exercise 4 (See NOTE): Monitor and troubleshoot Teams Phone
-
-> [!NOTE]
-> Tasks 2, 3, 5, 6, &amp; 7 are unable to be completed at this time. Due to a new verification requirement to meet compliance standards, ordering service and subscriber numbers for Microsoft Teams Phone is not possible in our tenant environment, which means we are unable to test and review live calls.  We hope to mitigate this issue in the future, but in the meantime, use the steps below as a general reference and follow along as practice.
+## Exercise 4: Monitor and troubleshoot Teams Phone
 
 ### Exercise Duration
 
   - **Estimated Time to complete**: 120 minutes
 
-In this exercise, you will perform exercises to help troubleshoot specific issues and monitor call use and quality.
+In this exercise, you will perform exercises to help troubleshoot specific issues and monitor call use and quality. All test calls in this exercise route through the Session Border Controller deployed in Lab 3.
 
 ### Task 1 - Run self-help diagnostics tool in Microsoft 365 admin center
 
@@ -561,7 +565,7 @@ You have successfully used the Microsoft 365 self-help diagnostics to confirm th
 
 In this lab, we are going to create and then break a dial plan rule and check Call Analytics to see the issue.
 
-Firstly, we will create a dial plan rule, in this scenario, the organization would like the short code 7786 to translate to +1-877-696-7786.
+Firstly, we will create a dial plan rule. In this scenario, the organization would like the short code 0001 to translate to the lab test number +1-425-555-0001 that's reachable through the SBC deployed in Lab 3.
 
 1. You are still signed in to **MS721-CLIENT01** as “Admin” and signed into the **Microsoft 365 admin center** as **MOD Administrator**.
 
@@ -573,21 +577,21 @@ Firstly, we will create a dial plan rule, in this scenario, the organization wou
     
     1. Under Normalization rules select **Add** to get to the add new rule dialogue.
     
-    1. For **Name** enter **Converts 7786 to US support number**.
+    1. For **Name** enter **Converts 0001 to lab test number**.
     
-    1. For **Description** enter **Converts 7786 to US support number**.
+    1. For **Description** enter **Converts 0001 to lab test number**.
     
     1. Ensure **Basic** rule is selected, it should be by default.
     
-    1. Tick **The number dialed begins with** and enter **7786**.
+    1. Tick **The number dialed begins with** and enter **0001**.
     
     1. Tick **The length of the number being dialed is** and enter **4**.
     
     1. Ensure **Exactly** is selected for length of number to be dialed.
     
-    1. Tick **Add this number to the beginning** and enter **+1877696**.
+    1. Tick **Add this number to the beginning** and enter **+1425555**.
     
-    1. Test the rule by entering **7786** and pressing Test. The output should be **+18776967786**, if the output is correct select **Save**.
+    1. Test the rule by entering **0001** and pressing Test. The output should be **+14255550001**, if the output is correct select **Save**.
     
     1. In the list of normalization rules, select the rule you just created and choose **Move up** from the action menu at the top of the table.
     
@@ -615,13 +619,13 @@ If the desktop client fails to update or loops, you can use the Teams web client
 
 1. Select the calls button on the left rail.
 
-1. Dial **7786** and press call.
+1. Dial **0001** and press call.
 
 1. If your lab machine prompted you to use your microphone select **Allow**.
 
 1. If you are prompted by Windows Defender Firewall for Microsoft Teams select **Allow Access**.
 
-1. Note that the number has been translated to +18776967786 and the call connects. It is a contact center that will stay connected for around a minute and then automatically hang up.
+1. Note that the number has been translated to +14255550001 and the call connects through the SBC.
 
 1. Press the red hang-up button to disconnect the call.
 
@@ -635,15 +639,15 @@ Now we have proven the rule works, we will break the rule and confirm the rule.
 
 1. Select the **Global (org wide default)** dial plan.
 
-1. Select the **Converts 7786 to US support number** rule to edit it.
+1. Select the **Converts 0001 to lab test number** rule to edit it.
 
 1. Note it will be converted to an advanced regular expression now.
 
-1. In the field the number dialed matches this regular expression, it will read **^(7786)$**.
+1. In the field the number dialed matches this regular expression, it will read **^(0001)$**.
 
-1. Remove the first 7 to now read, **^(786)$**.
+1. Remove the first 0 to now read, **^(001)$**.
 
-1. Test the rule by entering 7786 and pressing Test. The output of the translated number isn't an E.164 phone number.
+1. Test the rule by entering 0001 and pressing Test. The output of the translated number isn't an E.164 phone number.
 
 1. Select **Save**.
 
@@ -677,7 +681,7 @@ Now we have broken our dial plan, we will sign into Teams again and prove it is 
 
 1. Once signed in, Select the calls button on the left rail.
 
-1. Dial 7786 and press call.
+1. Dial 0001 and press call.
 
 1. If your lab machine prompted you to use your microphone select **Allow**.
 
@@ -701,13 +705,13 @@ Users can check on the network performance of their calls live during the call. 
 
 1. Select the calls button on the left rail.
 
-1. Dial +1-877-696-7786 and press call.
+1. Dial +1-425-555-0001 and press call.
 
 1. If your lab machine prompted you to use your microphone select **allow**.
 
 1. If you are prompted by Windows Defender Firewall for Microsoft Teams select **Allow Access**.
 
-1. The call should establish and you should hear a Microsoft support virtual agent.
+1. The call should establish through the SBC.
 
 1. While on the call, press the ellipsis (three dots) in the top right of the Teams client and select **Settings**, then **Call health**.
 

--- a/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
+++ b/Instructions/Labs/LAB_AK_05_manage_teams_devices.md
@@ -31,16 +31,13 @@ As part of the expanding business, the organization has began deploying various 
 > Throughout this lab, you will use PowerShell cmdlets that must be customized for your specific lab configuration. In the instructions below, when you see &lt;LAB NUMBER&gt; in a PowerShell command, you should replace it with the LAB NUMBER obtained in Lab 3, Exercise 1, Task 2.
 > You will also see &lt;TENANT NAME&GT; used in PowerShell commands and should replace it with the Microsoft 365 TENANT NAME (e.g. M365x01234567) for your Microsoft 365 account.
 
-## Exercise 1 (See NOTE): Configuring Teams Shared Device and Room Resource Accounts
-
-> [!NOTE]
-> Tasks 4 &amp; 5 are unable to be completed at this time. Due to a new verification requirement to meet compliance standards, ordering service and subscriber numbers for Microsoft Teams Phone is not possible in our tenant environment, which means we are unable to test and review live calls.  We hope to mitigate this issue in the future, but in the meantime, use the steps below as a general reference and follow along as practice.
+## Exercise 1: Configuring Teams Shared Device and Room Resource Accounts
 
 ### Exercise Duration
 
   - **Estimated Time to complete**: 30 minutes
 
-In this exercise, you will configure accounts for Teams Shared Devices and Rooms.
+In this exercise, you will configure accounts for Teams Shared Devices and Rooms. Because direct number ordering through the Teams admin center isn't available in this trial tenant, phone numbers are assigned to these resource accounts through **Direct Routing** PowerShell using the Session Border Controller deployed in Lab 3.
 
 ### Task 1 - Create a resource account for Teams Shared Devices (Common Area Phones)
 
@@ -72,9 +69,9 @@ In this task, you will sign into the Microsoft 365 admin center and will create 
 
     ![A screenshot showing the basics of user setup.](Linked_Image_Files/M05_L05_E01_T01_01.png)
 
-1. On the licensing page, assign both a **Microsoft Teams Rooms Pro** and a **Microsoft Teams Domestic Calling Plan** license to the user account, and then click **Next.**
+1. On the licensing page, assign a **Microsoft Teams Rooms Pro** license to the user account, and then click **Next.**
 
-    > NOTE: The lab environment does not have the proper **Teams Shared Devices** licensing avaliable. For what we need, this license will do for lab purposes.
+    > NOTE: The lab environment does not have the proper **Teams Shared Devices** licensing avaliable. For what we need, the Rooms Pro license will do for lab purposes. A Calling Plan license isn't required because this account will receive a phone number through **Direct Routing** in a later task.
 
 1. Continue clicking **Next** until you get the username and password presented to you. Write these down for future use. Keep the browser open for the next task.
 
@@ -104,7 +101,7 @@ In this task, you will sign into the Microsoft 365 admin center and will create 
 
 1. In the left navigation, select **Users**, select **Active Users**, and then select the **CONF_Room1** account. 
 
-1. Select **Licenses and Apps** on the user card, assign both a **Microsoft Teams Rooms Pro** and a **Microsoft Teams Domestic Calling Plan** license to the user account, and then click **Save changes.**
+1. Select **Licenses and Apps** on the user card, assign a **Microsoft Teams Rooms Pro** license to the user account, and then click **Save changes.** A Calling Plan license isn't required because the account will receive a phone number through **Direct Routing** in a later task.
 
 1. While still in the user card, select **Reset Password** and set the password to the **User password** for your Microsoft 365 account, then close the user card.
 
@@ -153,65 +150,42 @@ In this task, you will sign into the Microsoft Graph PowerShell Module and disab
 	```
 The accounts anow have password expiration disabled and are ready to have additional configurations applied.
 
-### Task 4 - Acquire phone numbers to assign to the resource accounts
+### Task 4 - Assign phone numbers to the resource accounts through Direct Routing
 
-In this task, you will sign into the Microsoft Teams admin center and will aquire two phone numbers for each resource account.
+In this task, you will use PowerShell to assign a Direct Routing phone number to each resource account. The numbers route through the SBC you deployed in Lab 3. (In a production environment without the current tenant restrictions, you would order Calling Plan numbers through the Teams admin center and assign them in the **Phone numbers** page. Because that's unavailable in this lab tenant, Direct Routing is used instead.)
 
-1. You are still signed in to MS721-CLIENT01 as “Admin” and in the **Microsoft Teams admin center** as **MOD Administrator**
+1. You are still signed in to MS721-CLIENT01 as **Admin** with the password provided to you.
 
-1. In the **Microsoft Teams admin center**, select **Voice** on the left menu, then select **Phone numbers**.
+1. Open Windows PowerShell and connect to Microsoft Teams. When prompted for credentials, sign in as **Allan Deyoung**:
 
-1. Under **Numbers**, select **Add**.
+    ```powershell
+    Connect-MicrosoftTeams
+    ```
 
-1. At the top of the page, enter a name for your order **Numbers for Resource Accounts**.
+1. Grant the `NA-National` voice routing policy you created in Lab 3 to both resource accounts so they can route calls through the SBC. Replace `<LAB Domain>` with your lab domain:
 
-1. For **description** enter **Numbers for Resource Accounts**.
+    ```powershell
+    Grant-CsOnlineVoiceRoutingPolicy -Identity CAP_Reception@<LAB Domain>.onmicrosoft.com -PolicyName "NA-National"
+    Grant-CsOnlineVoiceRoutingPolicy -Identity CONF_Room1@<LAB Domain>.onmicrosoft.com -PolicyName "NA-National"
+    ```
 
-1. Select **United States** as **Country or region**.
+1. Assign a Direct Routing phone number to each resource account:
 
-1. For Number Type, select **User (subscriber)**.
+    ```powershell
+    Set-CsPhoneNumberAssignment -Identity CAP_Reception@<LAB Domain>.onmicrosoft.com -PhoneNumber "+14255551201" -PhoneNumberType DirectRouting
+    Set-CsPhoneNumberAssignment -Identity CONF_Room1@<LAB Domain>.onmicrosoft.com -PhoneNumber "+14255551202" -PhoneNumberType DirectRouting
+    ```
 
-1. For Operator, select **Microsoft**.
+1. Confirm the assignments by running:
 
-1. The Quantity field will now appear, enter **2**.
+    ```powershell
+    Get-CsOnlineUser CAP_Reception | Select DisplayName, LineUri, OnlineVoiceRoutingPolicy
+    Get-CsOnlineUser CONF_Room1 | Select DisplayName, LineUri, OnlineVoiceRoutingPolicy
+    ```
 
-1. For **Search for new numbers** select **Search by area code** and enter **206**.
+1. Leave the PowerShell window open at the end of the task.
 
-    > NOTE: The phone numbers that are available in different regions will vary and **206** numbers may not be available. Try other area codes in the US and Canada, such as **308** in Nebraska.  The area code of the phone number does not need to match the emergency address location.
-
-1. When all fields are complete, select **Next**. Microsoft will now reserve phone numbers in the chosen area code. If there are no numbers available for your selected State/City combination, select another State/City and try again.
-
-1. Verify the area code and phone number, then select **Place Order**.
-
-1. You will see “Thank you, your order has been placed!”, select **Finish**.
-
-1. In the voice, under **phone numbers**, you should see your number. Note in some cases this may take 5-10 minutes to appear.
-
-1. Leave the browser window open at the end of the task.
-
-You have successfully ordered a User (subscriber) phone number through the Teams admin center.
-
-### Task 5 - Assign a phone number to each resource account
-
-In this task, you will sign into the Microsoft Teams admin center and will assign a phone number to each previously created account.
-
-1. You are still signed in to MS721-CLIENT01 as “Admin” and have the **Microsoft Teams admin center** open as **MOD Administrator**.
-
-1. Select **Voice** and the **Phone numbers** tab.
-
-1. Select the new user phone number we ordered in Task 2 for the room accounts.
-
-1. Select **Edit** from the top table menu.
-
-1. Enter **CAP_Reception** in the **Assigned To** field, then select **Assign**.
-
-1. Under **Emergency location**, select **Search by city**, and then enter **Bellevue** and select the address you verified earlier.
-
-1. Select **Apply**, then repeat for **CONF_Room1**, and then close any additional windows.
-
-1. The phone number is now assigned to the accounts.
-
-You have successfully assigned a phone number to the resource accounts.
+You have successfully assigned Direct Routing phone numbers to the resource accounts.
 
 ## Exercise 2: Deploy Microsoft Teams Common Area Phones
 


### PR DESCRIPTION
- Added notes regarding the unavailability of direct number ordering in trial tenants.
- Clarified the use of Direct Routing for phone number assignments in multiple labs.
- Revised exercise descriptions and tasks to reflect changes in licensing and phone number assignment processes.